### PR TITLE
Create non-uplinks before uplinks to fix misbehavior

### DIFF
--- a/builders/tests/test_uplink.py
+++ b/builders/tests/test_uplink.py
@@ -290,7 +290,7 @@ def test_collection_mid_uplink_zaa():
     A.b.linksTo(B, B.zaa)
 
     builder = Builder(B).withA(HavingIn(B.zaa, 1),
-                         HavingIn(C.bb, 1))
+                               HavingIn(C.bb, 1))
 
     c = builder.build().c
 


### PR DESCRIPTION
Fixes #3 

May be not the best fix possible but still.

Also, dont create the nested types -- that was not covered with tests after all.
